### PR TITLE
Updated build workflow and script organization

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -92,6 +92,10 @@ jobs:
           cmake --install build --config release
         shell: bash
 
+      - name: Copy launch script
+        run: cp ./scripts/usd_command_prompt.cmd ./usd-install/
+        shell: bash
+    
       - name: Remove usd-install/build folder
         run: rm -rf ./usd-install/build
         shell: bash

--- a/.github/workflows/sample_set_path.ps1
+++ b/.github/workflows/sample_set_path.ps1
@@ -1,9 +1,0 @@
-$env:PATH = "./usd-install/bin;./usd-install/lib;" + $env:PATH
-$env:PYTHONPATH = "./usd-install/lib/python;" + $env:PYTHONPATH
-$env:USD_INSTALL_PATH = "./usd-install"
-$env:USD_INSTALL_PATH_BIN = "./usd-install/bin"
-$env:USD_INSTALL_PATH_LIB = "./usd-install/lib"
-$env:USD_INSTALL_PYTHON_PATH = "./usd-install/lib/python"
-cmake -S . -B build -DBOOST_ROOT="./usd-install" -DCMAKE_INSTALL_PREFIX="./usd-install" -DUSD_FILEFORMATS_ENABLE_FBX=OFF -Dpxr_ROOT="./usd-install" -DUSD_FILEFORMATS_BUILD_TESTS=OFF -DUSD_FILEFORMATS_ENABLE_CXX11_ABI=ON
-cmake --build   build --config release
-cmake --install build --config release

--- a/scripts/usd_command_prompt.cmd
+++ b/scripts/usd_command_prompt.cmd
@@ -1,0 +1,4 @@
+@echo off
+set PATH=./bin;./lib;%PATH%
+set PYTHONPATH=./lib/python;%PYTHONPATH%
+start powershell.exe -NoExit


### PR DESCRIPTION
Fixes: #2 

The build workflow has been updated to include a step for copying the PowerShell script so the openusd paths are correct on startup.